### PR TITLE
Feature/workflow activation scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ src/Vyshyvanka.Api/packages/*
 .llm
 samples/
 test-results/.last-run.json
+.kiro/settings/cli.json
+src/Vyshyvanka.AppHost/aspire.config.json

--- a/.kiro/settings/cli.json
+++ b/.kiro/settings/cli.json
@@ -1,5 +1,0 @@
-{
-  "toolSearch.enabled": true,
-  "toolSearch.minPct": 0,
-  "toolSearch.minTokens": 0
-}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,8 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <!-- JavaScript Engine -->
     <PackageVersion Include="Jint" Version="4.16.0" />
+    <!-- Cron Expression Parsing -->
+    <PackageVersion Include="Cronos" Version="0.11.0" />
     <!-- JSONata Expression Language -->
     <PackageVersion Include="Jsonata.Net.Native" Version="3.0.0" />
     <!-- NuGet -->

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -15,6 +15,7 @@
 | Authentication | JWT Bearer + API Key (dual scheme); configurable OIDC (Keycloak, Authentik) or LDAP |
 | Encryption | AES-256 for credentials at rest; optional HashiCorp Vault / OpenBao integration |
 | Package Management | NuGet Protocol |
+| Scheduling | Cronos (cron expression parsing) |
 
 ## Project Structure
 
@@ -114,6 +115,7 @@ graph TB
         Auth["Auth Services<br/>JWT, Password Hashing"]
         Credentials["Credential Services<br/>AES-256 Encryption"]
         Packages["Package Manager<br/>NuGet Protocol"]
+        Scheduler["WorkflowSchedulerService<br/>Hosted BackgroundService (Cronos)"]
     end
 
     subgraph Foundation
@@ -134,6 +136,8 @@ graph TB
     Auth --> Persistence
     Credentials --> Persistence
     Packages --> Plugins
+    Scheduler --> EngineExec
+    Scheduler --> Persistence
     Persistence --> CoreModels
     Persistence --> CoreInterfaces
 ```
@@ -151,3 +155,4 @@ graph TB
 | Pluggable authentication provider | Configurable via `appsettings.json` — built-in JWT, Keycloak, Authentik OIDC, or LDAP directory with JIT user provisioning |
 | Topological sort for execution order | Guarantees correct data flow; detects cycles at execution time |
 | Optimistic concurrency on workflows | Version field prevents lost updates in concurrent editing scenarios |
+| In-process scheduler as a hosted `BackgroundService` | `WorkflowSchedulerService` (Engine `Scheduling/`) runs inside the Api process to dispatch cron/interval-scheduled executions; uses Cronos for cron parsing — see [04-workflow-engine.md](04-workflow-engine.md) for details |

--- a/docs/03-domain-model.md
+++ b/docs/03-domain-model.md
@@ -46,7 +46,7 @@ erDiagram
         string Name
         string Description
         int Version
-        bool IsActive
+        WorkflowStatus Status
         Guid FolderId FK
         DateTime CreatedAt
         DateTime UpdatedAt
@@ -170,6 +170,16 @@ erDiagram
 ```
 
 ## Enumerations
+
+### WorkflowStatus
+
+Controls whether a workflow's triggers are armed for automatic execution. Activation governs **only** whether automatic triggers fire — it does not gate manual, API, or Designer execution, which is always allowed subject to permissions and validation.
+
+| Value | Description |
+|-------|------------|
+| Draft | Editable; never armed. Runs only manually or via the API. |
+| Active | Armed for automatic triggers (webhook listening plus cron/interval scheduling). Also runnable manually. |
+| Paused | Triggers disarmed, but still runnable manually or via the API. |
 
 ### ExecutionStatus
 

--- a/docs/04-workflow-engine.md
+++ b/docs/04-workflow-engine.md
@@ -46,9 +46,11 @@ classDiagram
 
 ## Execution Flow
 
+Executions are dispatched through `IWorkflowEngine.ExecuteAsync` from several sources: an incoming webhook, a manual trigger from the API/Designer, or the **workflow scheduler** (see [Scheduling](#scheduling)) firing a time-based trigger. Regardless of the dispatch source, the flow below is identical — persistence and cancellation behave the same way.
+
 ```mermaid
 flowchart TD
-    Start([Trigger Fires]) --> CreateExec[Create Execution Record<br/>Status: Running]
+    Start([Trigger Fires<br/>webhook / manual / scheduled]) --> CreateExec[Create Execution Record<br/>Status: Running]
     CreateExec --> Topo[Build Execution Levels<br/>via Topological Sort]
     Topo --> CycleCheck{Cycle<br/>Detected?}
     CycleCheck -->|Yes| Fail[Fail: Workflow contains a cycle]
@@ -80,6 +82,52 @@ flowchart TD
     FailExec --> Persist[Persist Final Status]
     Complete --> Persist
     Fail --> Persist
+```
+
+## Scheduling
+
+Time-based workflows are driven by `WorkflowSchedulerService` — a hosted `BackgroundService` (in `Vyshyvanka.Engine/Scheduling/`) that polls **every 30 seconds** for workflows to fire. On each tick it selects workflows whose status is `Active` and whose graph contains a `schedule-trigger` node, then decides whether each one is due.
+
+The next fire time is computed by `ISchedulePlanner` / `SchedulePlanner` from the schedule-trigger node's configuration:
+
+- **`cronExpression`** — parsed via the [Cronos](https://github.com/HangfireIO/Cronos) library.
+- **`interval`** — a fixed number of seconds between runs.
+
+Due-ness is evaluated relative to a persisted per-workflow cursor, `LastScheduledFireAt`. When the computed next occurrence is at or before the current time, the workflow is due.
+
+When due, the scheduler dispatches an execution through the **same** `IWorkflowEngine.ExecuteAsync` the controllers use, so persistence and cancellation behave identically to webhook/manual runs. The execution is dispatched with `ExecutionMode.Scheduled`, and the execution context is seeded with:
+
+| Variable | Value |
+|----------|-------|
+| `triggerType` | `schedule` |
+| `scheduledTime` | The occurrence time the run was fired for |
+
+### Overlap Guard
+
+If a prior run of the same workflow is still `Running` or `Pending`, the tick is **skipped** for that workflow. A workflow never runs concurrently with itself via the scheduler.
+
+### Misfire Policy
+
+Occurrences missed while the host was down are **skipped** — there is no backfill. On startup the next occurrence is computed forward from the current time, so a workflow that missed several fires while offline runs once at its next due time rather than replaying every missed slot.
+
+### Deployment Model
+
+The scheduler is **single-instance** by design: exactly one `WorkflowSchedulerService` runs per deployment. Running multiple scheduler instances against the same database is not supported and would cause duplicate dispatches.
+
+```mermaid
+flowchart TD
+    Tick([Poll every 30s]) --> Query[Select Active workflows<br/>with a schedule-trigger node]
+    Query --> ForEach[For each workflow]
+    ForEach --> Plan[SchedulePlanner: compute next fire<br/>from cronExpression or interval<br/>relative to LastScheduledFireAt]
+    Plan --> Due{Due now?}
+    Due -->|No| Skip[Skip this tick]
+    Due -->|Yes| Overlap{Prior run still<br/>Running / Pending?}
+    Overlap -->|Yes| SkipOverlap[Skip: overlap guard]
+    Overlap -->|No| Dispatch[ExecuteAsync<br/>ExecutionMode.Scheduled<br/>triggerType=schedule, scheduledTime]
+    Dispatch --> Cursor[Advance LastScheduledFireAt]
+    Cursor --> ForEach
+    Skip --> ForEach
+    SkipOverlap --> ForEach
 ```
 
 ## Topological Sort and Parallel Execution

--- a/docs/05-node-system.md
+++ b/docs/05-node-system.md
@@ -77,7 +77,7 @@ Trigger nodes initiate workflow execution. They have no input ports and produce 
 | Node | Type Identifier | Description |
 |------|----------------|------------|
 | Webhook Trigger | `webhook-trigger` | Fires when an HTTP request hits the webhook endpoint. Passes method, headers, query params, body, and rawBody as output. Configuration: `responseMode` (`async` default, `sync` to hold connection for HTTP Response node), `responseTimeout` (seconds), `exposeAuthorizationHeader` (include Authorization header in output), `secret` (HMAC-SHA256 verification), `allowedIps` (IP allowlist). |
-| Schedule Trigger | `schedule-trigger` | Fires on a cron schedule. Passes the scheduled time as output. |
+| Schedule Trigger | `schedule-trigger` | Fires on a recurring schedule (standard 5-field cron via the Cronos library, or a fixed `interval` in seconds) in the workflow's configured timezone. A hosted background service (the workflow scheduler) polls active workflows every 30s and dispatches an execution when the schedule is due. Passes the scheduled time as output. |
 | Manual Trigger | `manual-trigger` | Fires when a user manually executes the workflow. Passes any provided input data. |
 
 ### Action Nodes

--- a/docs/06-api-reference.md
+++ b/docs/06-api-reference.md
@@ -60,11 +60,21 @@ Accounts are locked after 5 consecutive failed login attempts for 15 minutes. Se
 | PUT | `/api/workflow/{id}` | CanManageWorkflows | Update a workflow. Requires version for optimistic concurrency. Rejects duplicate webhook paths among active workflows (409). |
 | DELETE | `/api/workflow/{id}` | CanManageWorkflows | Delete a workflow. |
 
+**Workflow status.** Each workflow carries a `status` field (replaces the former `isActive` boolean). It is a numeric enum serialized over the wire as an integer (no `JsonStringEnumConverter` is registered):
+
+| Value | Name | Meaning |
+|-------|------|---------|
+| 0 | Draft | Not yet activated; automatic triggers do not fire. |
+| 1 | Active | Automatic triggers (Trigger, Scheduled) and webhooks are live. |
+| 2 | Paused | Temporarily suspended; automatic triggers do not fire. |
+
+`status` appears on `CreateWorkflowRequest`, `UpdateWorkflowRequest`, and `WorkflowResponse`. There is **no** dedicated status endpoint — status is set on create and changed through the existing `PUT /api/workflow/{id}` update endpoint. `GET /api/workflow/active` lists workflows whose `status` is `Active` (1).
+
 ### Executions
 
 | Method | Path | Auth Policy | Description |
 |--------|------|------------|------------|
-| POST | `/api/execution` | CanExecuteWorkflows | Trigger a workflow execution. Accepts workflow ID, input data, execution mode, optional `targetNodeId` for partial execution, and `includeTargetNode` (default true; when false, executes predecessors only and returns computed input for the target node). Requires workflow ownership or Admin role. |
+| POST | `/api/execution` | CanExecuteWorkflows | Trigger a workflow execution. Accepts workflow ID, input data, execution mode, optional `targetNodeId` for partial execution, and `includeTargetNode` (default true; when false, executes predecessors only and returns computed input for the target node). Requires workflow ownership or Admin role. **Status gate:** `Manual` and `Api` execution modes are allowed regardless of workflow status; `Trigger` and `Scheduled` modes require `status == Active` (1) and otherwise return `WORKFLOW_NOT_ACTIVE`. |
 | POST | `/api/execution/node` | CanExecuteWorkflows | Execute a single node with provided input data (no full workflow run). Used for quick iteration when the node config has no expression references. |
 | GET | `/api/execution` | CanViewWorkflows | Query execution history with filters (workflow ID, status, mode, date range). |
 | GET | `/api/execution/{id}` | CanViewWorkflows | Get execution details including node-level results. |
@@ -80,6 +90,8 @@ Accounts are locked after 5 consecutive failed login attempts for 15 minutes. Se
 | GET/POST/PUT/DELETE/PATCH | `/api/webhook/path/{*path}` | Anonymous | Trigger a workflow by matching webhook path configuration. |
 
 Webhook endpoints are anonymous to allow external systems to trigger workflows. The webhook controller builds a structured payload containing the HTTP method, path, query string, headers (excluding Authorization and Cookie), and body. Rate limited: 30 req/min per IP.
+
+Webhook endpoints serve only workflows whose `status` is `Active` (1). A request targeting a `Draft` or `Paused` workflow returns the `WORKFLOW_NOT_ACTIVE` error code (formerly `WORKFLOW_INACTIVE`).
 
 **Security controls (optional, per-workflow):**
 - **Request body size limit**: 1 MB maximum enforced on all webhook requests

--- a/docs/09-designer.md
+++ b/docs/09-designer.md
@@ -254,7 +254,9 @@ The main workspace containing:
 - Context panel (left, 240px) — content depends on active activity bar tab
 - Workflow canvas (center) — infinite pan/zoom workspace
 - Node configuration panel (right sidebar, 300px) — selected node properties
-- Toolbar (top) — workflow name, undo/redo, zoom, save, run
+- Toolbar (top) — workflow name, undo/redo, zoom, save, run, and a status control (Draft / Active / Paused)
+
+The status control sets the workflow's `status` (Draft, Active, or Paused), which is persisted through the standard `PUT /api/workflow/{id}` update — there is no separate status endpoint. Only `Active` workflows fire automatic triggers (Trigger, Scheduled) and respond to webhooks. The **Run** button is always enabled regardless of status: manual runs are permitted for any status (Manual and Api execution modes are not gated on activation).
 
 ### NotFound
 

--- a/docs/nodes/schedule-trigger.md
+++ b/docs/nodes/schedule-trigger.md
@@ -25,7 +25,16 @@ Provide either `cronExpression` or `interval`, not both.
 
 ## Behavior
 
-The Schedule Trigger activates when the scheduler determines it is time to run based on the configured cron expression or interval.
+The Schedule Trigger is driven by the platform's workflow scheduler — a hosted background service that polls every 30 seconds. On each poll it evaluates all workflows whose status is `Active` and that contain a schedule-trigger node, and fires the trigger when its configured schedule is due:
+
+- `cronExpression` — a standard 5-field cron expression, parsed with the Cronos library.
+- `interval` — a fixed interval in seconds.
+
+Due times are computed in the workflow's configured `timezone` (default `UTC`).
+
+Notes:
+- The workflow must be `Active` for the schedule to fire — inactive workflows are ignored by the scheduler.
+- Runs are not backfilled: any schedule occurrences that fall due while the host is down are skipped rather than replayed on restart.
 
 Trigger validation:
 - The trigger context must contain schedule data with `triggerType` equal to `"schedule"`

--- a/docs/sdd/workflow-activation-and-scheduler.md
+++ b/docs/sdd/workflow-activation-and-scheduler.md
@@ -1,0 +1,341 @@
+# SDD — Workflow Activation Model & Scheduler
+
+Software Design Document for decoupling workflow **activation** from **executability**, and implementing the currently-missing **cron/interval scheduler**.
+
+Status: **Proposed** · Scope: `Vyshyvanka.Core`, `Vyshyvanka.Engine`, `Vyshyvanka.Contracts`, `Vyshyvanka.Api`, `Vyshyvanka.Designer`
+
+---
+
+## 1. Problem Statement
+
+Today a workflow has a single `bool IsActive` (default `false`) that governs **both**:
+
+1. Whether automatic triggers are armed (webhook path listening; and — once built — cron scheduling), and
+2. Whether the workflow can be executed **at all** (manual/API/designer runs are blocked when inactive).
+
+Conflating these makes it impossible to develop and test a production workflow without arming its live triggers. The concrete concern: *a workflow that is active and carries a cron trigger would fire in the middle of development.*
+
+There is a second, hidden problem the research surfaced: **there is no scheduler**. `ScheduleTriggerNode` is never invoked by anything. `GetNextExecutionTime` is a stub (`return fromTime.AddMinutes(1);` with a `// use a library like Cronos` comment). A solution-wide search for `IHostedService` / `BackgroundService` / `Quartz` / `Cronos` finds only that comment and a client-side Blazor UI poll. So cron triggers **never fire**, and the activation flag has no cron enforcement point because there is no cron dispatch to enforce it in.
+
+This SDD addresses both: it introduces a proper activation **state model** and implements the missing **scheduler** so that `Active` genuinely means "runs automatically."
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+
+- Split "triggers armed" from "can be executed."
+- **Inactive/Draft** workflows remain executable from the Designer and via direct API (subject to permissions + validation) but do **not** respond to automatic triggers.
+- **Active** workflows respond to automatic triggers: webhook listening (already works) **and** cron/interval scheduling (new).
+- Replace the bare `bool IsActive` with a `WorkflowStatus` state model that leaves room for future states.
+- Implement a real cron scheduler backed by `Cronos`, dispatching executions with `ExecutionMode.Scheduled`.
+- Preserve backward compatibility for existing persisted workflows via a data migration.
+
+### Non-Goals
+
+- Distributed/multi-instance scheduler coordination (leader election, distributed locks). Single-instance is assumed for v1; §9 notes the extension path.
+- Per-user or per-team scheduling quotas.
+- Catch-up / backfill of missed runs while the host was down (misfire policy is "skip", see §6.4).
+- Changing the webhook activation path beyond renaming the gate from `IsActive` to `Status == Active`.
+
+---
+
+## 3. Current State (verified against code)
+
+| Concern | Where enforced today | Behaviour |
+|---|---|---|
+| Domain flag | `Core/Models/Workflow.cs` → `bool IsActive` (default `false`) | Single boolean |
+| Persistence | `Engine/Persistence/Entities/WorkflowEntity.cs` → `bool IsActive`, non-null column, **indexed** (`IX_Workflows_IsActive`) | Round-tripped in `WorkflowRepository` |
+| Manual/API execution | `Api/Controllers/ExecutionController.cs` `TriggerExecution` → `if (!workflow.IsActive) → WORKFLOW_INACTIVE` | **Blocks** when inactive |
+| Single-node / partial run | `ExecutionController.ExecuteSingleNode` + `TargetNodeId` branch | **Does NOT** check `IsActive` (permission only) |
+| Webhook by-id | `Api/Controllers/WebhookController.cs` → `if (!workflow.IsActive) → WORKFLOW_INACTIVE` | Blocks |
+| Webhook by-path | `WorkflowRepository.GetByWebhookPathAsync` → `.Where(w => w.IsActive && ...)` | Inactive is invisible |
+| Sub-workflow | `Engine/Nodes/Actions/ExecuteWorkflowNode.cs` → fails if `!IsActive` | Blocks |
+| Cron scheduling | **none** — no scheduler exists | Never fires |
+| Contracts | `Contracts/Workflows/WorkflowContracts.cs` → `IsActive` on Create/Update/Response | Exposed |
+| Designer | `Designer/Services/WorkflowEditService.cs` → `SetWorkflowActive` / `ToggleWorkflowActive` | Boolean toggle |
+| Descriptive mode | `Core/Enums/ExecutionMode.cs` → `Manual/Trigger/Api/Scheduled` | Label only, nothing branches on it |
+
+Validation (`Engine/Validation/WorkflowValidator.cs`) does **not** reference the activation flag — activation is a runtime gate, not a structural-validation concern. This SDD keeps it that way.
+
+---
+
+## 4. Target Design
+
+### 4.1 State model
+
+Introduce `WorkflowStatus` in `Vyshyvanka.Core/Enums/`:
+
+```csharp
+namespace Vyshyvanka.Core.Enums;
+
+/// <summary>Lifecycle/activation state of a workflow.</summary>
+public enum WorkflowStatus
+{
+    /// <summary>Editable, never armed. Runs only manually / via direct API. Default for new workflows.</summary>
+    Draft,
+
+    /// <summary>Armed for automatic triggers (webhook listening + cron/interval scheduling). Also runnable manually.</summary>
+    Active,
+
+    /// <summary>Triggers disarmed (cron unscheduled, webhook not listening) but still runnable manually / via API.</summary>
+    Paused
+}
+```
+
+Semantics:
+
+| Status | Manual / API / Designer run | Webhook listening | Cron/interval scheduling |
+|---|:---:|:---:|:---:|
+| `Draft` | ✅ (validation + permission) | ❌ | ❌ |
+| `Active` | ✅ | ✅ | ✅ |
+| `Paused` | ✅ | ❌ | ❌ |
+
+`Draft` vs `Paused` differ only in intent/UX: `Draft` = never been armed; `Paused` = was active, temporarily disarmed. Both are "triggers off, manual on." Keeping both gives the Designer a meaningful lifecycle (Draft → Active → Paused → Active) without extra states.
+
+> Decision D1: three states, not a bool. A bool cannot express "was active, now paused" vs "never active" — a distinction users expect from n8n/Make. If the team prefers minimal surface, a two-state `Draft/Active` is a valid fallback (see §11 Alternatives).
+
+### 4.2 The single executability rule
+
+**Manual/API/Designer execution is always allowed** regardless of status (subject to permission + validation). Only automatic-trigger entry points check `Status == Active`.
+
+Concretely, the `WORKFLOW_INACTIVE` gate is **removed** from `ExecutionController.TriggerExecution`. It is **replaced** by an `ExecutionMode`-aware guard so that requests claiming an automatic mode still require `Active`:
+
+```csharp
+// ExecutionController.TriggerExecution, replacing the current IsActive block
+if (request.Mode is ExecutionMode.Trigger or ExecutionMode.Scheduled
+    && workflow.Status != WorkflowStatus.Active)
+{
+    return BadRequest(new ApiError
+    {
+        Code = "WORKFLOW_NOT_ACTIVE",
+        Message = "Automatic triggers are only served for active workflows"
+    });
+}
+// Manual and Api modes: no status gate — permission + validation already checked.
+```
+
+> Decision D2: the manual API path stops gating on activation entirely; the scheduler and webhook receiver are the only callers that pass `Trigger`/`Scheduled` mode, so the guard above is what actually arms/disarms automatic behaviour at the execution boundary. This is defense-in-depth on top of the scheduler simply not enqueueing non-active workflows (§6).
+
+### 4.3 Enforcement point matrix (target)
+
+| Entry point | Gate (target) |
+|---|---|
+| `ExecutionController.TriggerExecution`, `Mode = Manual`/`Api` | none (permission + validation only) |
+| `ExecutionController.TriggerExecution`, `Mode = Trigger`/`Scheduled` | `Status == Active` |
+| `ExecutionController.ExecuteSingleNode` | unchanged (permission only) |
+| `WebhookController` (by id + by path) | `Status == Active` |
+| `WorkflowRepository.GetByWebhookPathAsync` | `.Where(w => w.Status == WorkflowStatus.Active && ...)` |
+| `ExecuteWorkflowNode` (sub-workflow) | see D3 |
+| Scheduler (new) | only enqueues `Status == Active` workflows with a schedule trigger |
+
+> Decision D3: `ExecuteWorkflowNode` currently fails on `!IsActive`. A sub-workflow invoked by a parent is a *programmatic* call, closer to manual than to an automatic trigger. **Recommend loosening it to allow `Draft`/`Paused` sub-workflows** (block only an explicit `Archived` state if we ever add one), so a parent workflow can orchestrate un-armed children. Flagged for the reviewer — this is a behaviour change some may want to keep strict.
+
+### 4.4 Scheduler architecture
+
+A single hosted `BackgroundService` in `Vyshyvanka.Engine/Scheduling/` owns cron/interval dispatch.
+
+```mermaid
+flowchart TD
+    subgraph Host["Vyshyvanka.Api process"]
+        S["WorkflowSchedulerService<br/>(BackgroundService)"]
+        R["ISchedulePlanner<br/>(computes next-fire per workflow)"]
+        E["IWorkflowEngine<br/>(PersistentWorkflowEngine)"]
+    end
+    DB[("Workflows table<br/>Status = Active")]
+    S -->|poll active + schedule-trigger workflows| DB
+    S -->|next-fire time| R
+    R -->|due now?| S
+    S -->|dispatch ExecutionMode.Scheduled| E
+    E -->|create Execution, run graph| DB
+```
+
+Dispatch loop (tick every `SchedulerPollInterval`, default 30s):
+
+1. Load `Status == Active` workflows whose node graph contains a `schedule-trigger` node. (Reuse the `IX_Workflows_Status` index; schedule-trigger presence is detected from `NodesJson`, mirroring the existing webhook-path `LIKE` query pattern.)
+2. For each, compute `next-fire` from its `cronExpression` (via `Cronos.CronExpression`) or `interval`, relative to `lastFiredAt` (persisted, §5).
+3. If `next-fire <= now` (within tolerance), dispatch an execution with `ExecutionMode.Scheduled`, populating the trigger context so `ScheduleTriggerNode.ShouldTriggerAsync` returns true:
+   ```csharp
+   context.Variables["triggerType"]   = "schedule";
+   context.Variables["scheduledTime"] = nextFire;   // within the node's 60s tolerance
+   ```
+4. Persist `lastFiredAt = nextFire`; recompute `next-fire`.
+5. Overlap policy: if the workflow's previous scheduled execution is still `Running`, **skip** this tick (no concurrent scheduled runs of the same workflow). Configurable later.
+
+The scheduler calls the **same** `IWorkflowEngine.ExecuteAsync` the controllers use, so persistence, node-output storage, and cancellation all behave identically. It creates the same `ExecutionContext` shape the `ExecutionController` builds.
+
+> Decision D4: poll-based, not a per-workflow timer. Polling every 30s is simple, survives config changes without timer bookkeeping, and matches the `ScheduleTriggerNode`'s existing 60s tolerance window. Per-workflow `PeriodicTimer` bookkeeping is deferred (§9).
+
+### 4.5 Real cron parsing
+
+Replace `ScheduleTriggerNode.GetNextExecutionTime` (currently a stub) with a `Cronos`-backed planner. Add `Cronos` to `Directory.Packages.props` and reference it from `Vyshyvanka.Engine`.
+
+```csharp
+// Engine/Scheduling/SchedulePlanner.cs
+using Cronos;
+
+public sealed class SchedulePlanner : ISchedulePlanner
+{
+    public DateTime? GetNextOccurrence(string? cronExpression, int? intervalSeconds, DateTime fromUtc, string timeZoneId = "UTC")
+    {
+        if (intervalSeconds is > 0)
+        {
+            return fromUtc.AddSeconds(intervalSeconds.Value);
+        }
+
+        if (string.IsNullOrWhiteSpace(cronExpression))
+        {
+            return null;
+        }
+
+        var expr = CronExpression.Parse(cronExpression, CronFormat.Standard); // 5-field
+        var tz = TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        return expr.GetNextOccurrence(fromUtc, tz);
+    }
+}
+```
+
+`ScheduleTriggerNode.GetNextExecutionTime` delegates to `ISchedulePlanner` (kept as a thin static shim for existing callers/tests, or removed if none — verify at implementation time).
+
+---
+
+## 5. Data Model & Migration
+
+### 5.1 Entity changes
+
+`WorkflowEntity`:
+
+- Replace `public bool IsActive { get; set; }` with `public WorkflowStatus Status { get; set; }` (stored as `int`, EF default enum mapping).
+- Add `public DateTime? LastScheduledFireAt { get; set; }` (nullable UTC) — the scheduler's cursor. Only set for scheduled workflows.
+
+`Workflow` (Core model): replace `bool IsActive` with `WorkflowStatus Status`. (`LastScheduledFireAt` is engine/persistence-internal; it need not surface on the Core model or Contracts — keep it in the entity/repository layer.)
+
+Index: replace `IX_Workflows_IsActive` with `IX_Workflows_Status` (the scheduler and webhook queries both filter on `Status == Active`).
+
+### 5.2 EF migration
+
+Add migration `WorkflowStatusAndSchedulerCursor`:
+
+```
+dotnet ef migrations add WorkflowStatusAndSchedulerCursor \
+  --project src/Vyshyvanka.Engine --startup-project src/Vyshyvanka.Api \
+  --output-dir Persistence/Migrations
+```
+
+Per the project's migration convention (steering `tech.md`): **strip `type:` parameters** from column definitions and **remove any `Npgsql:*` annotations / `using Npgsql...Metadata;`** from the generated `.cs` so the migration stays provider-agnostic (PostgreSQL + SQLite).
+
+Data backfill (in the migration's `Up`, provider-agnostic): add `Status` column with default `0`, run an `UPDATE` mapping `IsActive=true → Active (1)` else `Draft (0)`, then drop `IsActive` and its index, then create `IX_Workflows_Status`.
+
+`Down` reverses: add `IsActive`, backfill `IsActive = (Status == 1)`, drop `Status` + `LastScheduledFireAt`, restore `IX_Workflows_IsActive`.
+
+> Note: mapping `Active → Active` and everything else (including a hypothetical future `Paused`) to `Draft` on downgrade is lossy but acceptable for a `Down`.
+
+---
+
+## 6. Behavioural Specification
+
+### 6.1 Manual run from Designer / API
+Allowed for any `Status`. The Designer's "Run" button always works; no more `WORKFLOW_INACTIVE` on a draft.
+
+### 6.2 Webhook
+Served only when `Status == Active`. By-path lookup filters on `Status == Active`; by-id re-checks. Response for non-active: `WORKFLOW_NOT_ACTIVE`.
+
+### 6.3 Cron/interval
+The scheduler enqueues an execution only for `Status == Active` workflows containing a `schedule-trigger` node, at the computed next-fire time, with `ExecutionMode.Scheduled`.
+
+### 6.4 Misfire / catch-up
+If the host was down across one or more fire times, on restart the scheduler computes the **next** occurrence from `now` (not from `lastFiredAt`), i.e. **skips** missed runs. No backfill in v1.
+
+### 6.5 Activation transitions (Designer)
+- Draft → Active: validate the workflow first (must pass `WorkflowValidator`); reject activation of an invalid workflow with `WORKFLOW_VALIDATION_FAILED`. This is the one place activation touches validation — arming an invalid workflow is nonsensical.
+- Active → Paused / Paused → Active: no validation gate (already validated once); simply flips trigger arming.
+- On any transition **away** from `Active`, leave `LastScheduledFireAt` as-is; on transition **to** `Active`, set `LastScheduledFireAt = now` so the first scheduled fire is computed forward from activation.
+
+---
+
+## 7. API & Contract Changes
+
+`Contracts/Workflows/WorkflowContracts.cs`:
+
+- `CreateWorkflowRequest` / `UpdateWorkflowRequest`: replace `bool IsActive` with `WorkflowStatus Status` (default `Draft`). (`WorkflowStatus` lives in `Core.Enums`, which Contracts already depends on — allowed per dependency rules.)
+- `WorkflowResponse`: replace `bool IsActive` with `WorkflowStatus Status`.
+
+New error codes (surfaced by the API): `WORKFLOW_NOT_ACTIVE` (replaces `WORKFLOW_INACTIVE`), `WORKFLOW_VALIDATION_FAILED` (on Draft→Active of an invalid workflow).
+
+`WorkflowController` create/update mapping updates request `Status` → model `Status`. **Recommend** a dedicated `POST api/workflow/{id}/status { status }` endpoint so the activation-time validation (§6.5) lives in one place, rather than overloading the general update path.
+
+---
+
+## 8. Designer Changes
+
+- `WorkflowEditService`: replace `SetWorkflowActive(bool)` / `ToggleWorkflowActive()` with `SetWorkflowStatus(WorkflowStatus)`.
+- Replace the boolean toggle in the toolbar with a status control (Draft / Active / Paused) — a segmented control or dropdown, using existing `v-*` classes per the design-to-code steering.
+- Show validation errors inline when Draft→Active fails.
+- "Run" button is always enabled (no longer disabled on inactive).
+
+(UI is per the design-system docs in `docs/design/`; exact control choice to be mocked before build per the frontend-design-workflow.)
+
+---
+
+## 9. Scheduler Robustness (single-instance v1, multi-instance path)
+
+v1 assumes one API instance runs the scheduler. For multi-instance later:
+
+- Add a leader-election / advisory-lock so only one instance dispatches (e.g. PostgreSQL advisory lock, or a `SchedulerLease` row with TTL). SQLite deployments are inherently single-instance.
+- The `LastScheduledFireAt` cursor + a per-tick `UPDATE ... WHERE LastScheduledFireAt = <expected>` optimistic guard prevents double-fire even if two instances briefly race.
+
+Deferred from v1; noted so the schema (`LastScheduledFireAt` as the concurrency cursor) is chosen with it in mind.
+
+---
+
+## 10. Testing Strategy
+
+Per steering (`xUnit` + `CsCheck` + `NSubstitute`, naming `When{Condition}Then{Expected}`):
+
+- **Unit — `SchedulePlanner`**: cron parsing (`0 9 * * 1-5`, `*/15 * * * *`), interval, timezone, invalid expression → null. Property test (CsCheck): next-occurrence is always `> fromUtc`.
+- **Unit — status gate**: `TriggerExecution` with `Mode=Manual` on a `Draft` workflow → allowed; `Mode=Scheduled` on `Draft`/`Paused` → `WORKFLOW_NOT_ACTIVE`; `Active` → allowed.
+- **Unit — scheduler dispatch**: fake `ISchedulePlanner` + substituted `IWorkflowEngine`; assert it enqueues only `Active` + schedule-trigger workflows, sets `ExecutionMode.Scheduled`, skips when a prior run is `Running`, and skips missed fires on restart.
+- **Unit — activation transition**: Draft→Active on invalid workflow → `WORKFLOW_VALIDATION_FAILED`; on valid → `Active` and `LastScheduledFireAt` set.
+- **Migration round-trip**: `IsActive=true → Active`, `false → Draft`; `Down` reverses.
+- **Integration** (`WebApplicationFactory` + EF InMemory/SQLite): webhook by-path returns not-active for `Draft`; manual run of `Draft` returns 202.
+- **Serialization** (CsCheck): `WorkflowStatus` round-trips through `System.Text.Json` (camelCase, source-gen context updated).
+
+---
+
+## 11. Alternatives Considered
+
+- **Option A (minimal, no enum, no scheduler):** keep `bool IsActive`, just drop the manual-execution gate. Ships immediately, zero migration. Rejected *for this SDD* because it leaves the scheduler unbuilt (so "active" still doesn't mean "runs automatically") — but it is the correct **first PR** if the team wants to split delivery (see §12).
+- **Two-state `Draft/Active` enum:** simpler than three states; loses the Paused/Draft distinction. Acceptable fallback if reviewers find `Paused` redundant.
+- **Quartz.NET instead of a hand-rolled `BackgroundService`:** heavier dependency, its own job store and clustering. Overkill for a single-instance cron loop over a handful of workflows; `Cronos` (parsing only) + a `BackgroundService` is far lighter and matches the codebase style. Revisit if distributed scheduling with persistence-of-jobs becomes a hard requirement.
+
+---
+
+## 12. Delivery Plan (suggested PR split)
+
+1. **PR-1 — Decouple (behaviour, no scheduler):** `WorkflowStatus` enum + entity/model/Contracts + migration + move the execution gate to be `ExecutionMode`-aware + webhook/repo query updates + Designer status control. Ships the core ask (develop an "active" workflow without a live cron firing) even before the scheduler exists — because with the mode-aware gate, no path fires a cron anyway.
+2. **PR-2 — Scheduler:** `Cronos`, `ISchedulePlanner`, `WorkflowSchedulerService` (`BackgroundService`), DI registration in `ServiceCollectionExtensions`, real cron parsing, `LastScheduledFireAt` cursor, tests. Delivers end-to-end "Active = runs automatically."
+3. **PR-3 (optional) — multi-instance hardening** per §9, only if/when a second instance is deployed.
+
+---
+
+## 13. Documentation Impact (general docs in `docs/`)
+
+These general docs describe the current single-boolean model and must be updated when this SDD lands:
+
+- `docs/03-domain-model.md` — enumerations section: add `WorkflowStatus`; workflow invariants mention activation.
+- `docs/04-workflow-engine.md` — execution flow "Trigger Fires" now includes a scheduler dispatch source; add a Scheduling section.
+- `docs/05-node-system.md` / `docs/nodes/schedule-trigger.md` — Schedule Trigger "Behavior" currently says "activates when the scheduler determines" but no scheduler exists; update once real.
+- `docs/06-api-reference.md` — replace `isActive` request/response field with `status`; document new error codes and the status endpoint.
+- `docs/09-designer.md` — replace the active toggle description with the status control.
+- `docs/02-architecture.md` — note the new hosted `BackgroundService` scheduler in the layered/architecture overview.
+
+---
+
+## 14. Open Questions for Reviewer
+
+1. **D1** — Three states (`Draft/Active/Paused`) or minimal two (`Draft/Active`)?
+2. **D3** — Should `ExecuteWorkflowNode` (sub-workflow) allow `Draft`/`Paused` children, or stay strict (active-only)?
+3. **§7** — Dedicated `POST api/workflow/{id}/status` endpoint, or carry `Status` through the existing update endpoint?
+4. **§6.4** — Confirm "skip missed runs" misfire policy (no backfill) is acceptable for v1.
+5. **§12** — Deliver as one PR or split into PR-1 (decouple) then PR-2 (scheduler)?

--- a/src/Vyshyvanka.Api/Controllers/ExecutionController.cs
+++ b/src/Vyshyvanka.Api/Controllers/ExecutionController.cs
@@ -79,12 +79,16 @@ public class ExecutionController : VyshyvankaControllerBase
             });
         }
 
-        if (!workflow.IsActive)
+        // Activation gate: automatic-trigger modes (Trigger/Scheduled) are only served for Active
+        // workflows. Manual and Api runs are always allowed so a Draft/Paused workflow can be
+        // developed and tested from the Designer or via direct API.
+        if (request.Mode is ExecutionMode.Trigger or ExecutionMode.Scheduled
+            && workflow.Status != WorkflowStatus.Active)
         {
             return BadRequest(new ApiError
             {
-                Code = "WORKFLOW_INACTIVE",
-                Message = "Cannot execute an inactive workflow"
+                Code = "WORKFLOW_NOT_ACTIVE",
+                Message = "Automatic triggers are only served for active workflows"
             });
         }
 

--- a/src/Vyshyvanka.Api/Controllers/WebhookController.cs
+++ b/src/Vyshyvanka.Api/Controllers/WebhookController.cs
@@ -120,11 +120,11 @@ public class WebhookController : ControllerBase
             });
         }
 
-        if (!workflow.IsActive)
+        if (workflow.Status != WorkflowStatus.Active)
         {
             return BadRequest(new ApiError
             {
-                Code = "WORKFLOW_INACTIVE",
+                Code = "WORKFLOW_NOT_ACTIVE",
                 Message = "Cannot trigger an inactive workflow"
             });
         }

--- a/src/Vyshyvanka.Api/Controllers/WorkflowController.cs
+++ b/src/Vyshyvanka.Api/Controllers/WorkflowController.cs
@@ -374,7 +374,7 @@ public class WorkflowController : VyshyvankaControllerBase
             Name = request.Name,
             Description = request.Description,
             Version = 1,
-            IsActive = request.IsActive,
+            Status = request.Status,
             Nodes = request.Nodes.Select(MapToNode).ToList(),
             Connections = request.Connections.Select(MapToConnection).ToList(),
             Settings = MapToSettings(request.Settings),
@@ -392,7 +392,7 @@ public class WorkflowController : VyshyvankaControllerBase
             Name = request.Name,
             Description = request.Description,
             Version = existing.Version + 1,
-            IsActive = request.IsActive,
+            Status = request.Status,
             Nodes = request.Nodes.Select(MapToNode).ToList(),
             Connections = request.Connections.Select(MapToConnection).ToList(),
             Settings = MapToSettings(request.Settings),
@@ -462,7 +462,7 @@ public class WorkflowController : VyshyvankaControllerBase
         Workflow workflow, CancellationToken cancellationToken)
     {
         // Only enforce uniqueness for active workflows
-        if (!workflow.IsActive)
+        if (workflow.Status != Core.Enums.WorkflowStatus.Active)
         {
             return null;
         }

--- a/src/Vyshyvanka.Api/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Vyshyvanka.Api/Extensions/ServiceCollectionExtensions.cs
@@ -102,6 +102,11 @@ public static class ServiceCollectionExtensions
             return new PersistentWorkflowEngine(innerEngine, repository);
         });
 
+        // Register the workflow scheduler (cron/interval dispatch for active workflows)
+        services.AddSingleton<Vyshyvanka.Engine.Scheduling.ISchedulePlanner,
+            Vyshyvanka.Engine.Scheduling.SchedulePlanner>();
+        services.AddHostedService<Vyshyvanka.Engine.Scheduling.WorkflowSchedulerService>();
+
         // Register credential services
         services.AddScoped<ICredentialRepository, CredentialRepository>();
 

--- a/src/Vyshyvanka.Api/Models/WorkflowDtos.cs
+++ b/src/Vyshyvanka.Api/Models/WorkflowDtos.cs
@@ -13,7 +13,7 @@ public static class WorkflowMappings
             Name = workflow.Name,
             Description = workflow.Description,
             Version = workflow.Version,
-            IsActive = workflow.IsActive,
+            Status = workflow.Status,
             Nodes = workflow.Nodes.Select(n => new WorkflowNodeDto
             {
                 Id = n.Id,

--- a/src/Vyshyvanka.Contracts/Workflows/WorkflowContracts.cs
+++ b/src/Vyshyvanka.Contracts/Workflows/WorkflowContracts.cs
@@ -14,8 +14,8 @@ public record CreateWorkflowRequest
     /// <summary>Optional free-text description explaining the workflow's purpose.</summary>
     public string? Description { get; init; }
 
-    /// <summary>Whether the workflow is active. Only active workflows respond to their trigger.</summary>
-    public bool IsActive { get; init; }
+    /// <summary>Activation state. Only <see cref="WorkflowStatus.Active"/> workflows respond to automatic triggers (webhook, cron). Manual/API execution is always allowed.</summary>
+    public WorkflowStatus Status { get; init; }
 
     /// <summary>The nodes that make up the workflow graph. Must contain exactly one trigger node.</summary>
     public List<WorkflowNodeDto> Nodes { get; init; } = [];
@@ -41,8 +41,8 @@ public record UpdateWorkflowRequest
     /// <summary>Optional free-text description explaining the workflow's purpose.</summary>
     public string? Description { get; init; }
 
-    /// <summary>Whether the workflow is active. Only active workflows respond to their trigger.</summary>
-    public bool IsActive { get; init; }
+    /// <summary>Activation state. Only <see cref="WorkflowStatus.Active"/> workflows respond to automatic triggers (webhook, cron). Manual/API execution is always allowed.</summary>
+    public WorkflowStatus Status { get; init; }
 
     /// <summary>The full replacement set of nodes for the workflow graph. Must contain exactly one trigger node.</summary>
     public List<WorkflowNodeDto> Nodes { get; init; } = [];
@@ -147,8 +147,8 @@ public record WorkflowResponse
     /// <summary>Current version number, incremented on each successful update for optimistic concurrency.</summary>
     public int Version { get; init; }
 
-    /// <summary>Whether the workflow is active and will respond to its trigger.</summary>
-    public bool IsActive { get; init; }
+    /// <summary>Activation state. Only <see cref="WorkflowStatus.Active"/> workflows respond to automatic triggers (webhook, cron). Manual/API execution is always allowed.</summary>
+    public WorkflowStatus Status { get; init; }
 
     /// <summary>The nodes that make up the workflow graph.</summary>
     public List<WorkflowNodeDto> Nodes { get; init; } = [];

--- a/src/Vyshyvanka.Core/Enums/WorkflowStatus.cs
+++ b/src/Vyshyvanka.Core/Enums/WorkflowStatus.cs
@@ -1,0 +1,29 @@
+namespace Vyshyvanka.Core.Enums;
+
+/// <summary>
+/// Lifecycle and activation state of a workflow.
+/// </summary>
+/// <remarks>
+/// Activation governs only whether automatic triggers are armed (webhook listening and
+/// cron/interval scheduling). It does NOT gate manual, API, or Designer execution, which is
+/// always permitted subject to permissions and validation.
+/// </remarks>
+public enum WorkflowStatus
+{
+    /// <summary>
+    /// Editable and never armed. Runs only manually or via direct API. Default for new workflows.
+    /// </summary>
+    Draft,
+
+    /// <summary>
+    /// Armed for automatic triggers: webhook listening and cron/interval scheduling.
+    /// Also runnable manually.
+    /// </summary>
+    Active,
+
+    /// <summary>
+    /// Triggers disarmed (cron unscheduled, webhook not listening) but still runnable
+    /// manually or via API. Distinguishes a previously-active workflow from one that was never armed.
+    /// </summary>
+    Paused
+}

--- a/src/Vyshyvanka.Core/Models/Workflow.cs
+++ b/src/Vyshyvanka.Core/Models/Workflow.cs
@@ -30,9 +30,12 @@ public record Workflow
     [Range(0, int.MaxValue, ErrorMessage = "Version must be non-negative")]
     public int Version { get; init; }
 
-    /// <summary>Whether the workflow is active and can be triggered.</summary>
-    [JsonPropertyName("isActive")]
-    public bool IsActive { get; init; }
+    /// <summary>
+    /// Activation state. Governs whether automatic triggers (webhook, cron/interval) are armed;
+    /// does not gate manual/API/Designer execution. Defaults to <see cref="WorkflowStatus.Draft"/>.
+    /// </summary>
+    [JsonPropertyName("status")]
+    public WorkflowStatus Status { get; init; }
 
     /// <summary>Nodes in the workflow.</summary>
     [JsonPropertyName("nodes")]

--- a/src/Vyshyvanka.Designer/Components/NodeEditor/NodeConfigPanel.razor
+++ b/src/Vyshyvanka.Designer/Components/NodeEditor/NodeConfigPanel.razor
@@ -197,8 +197,8 @@
             <div class="config-card">
                 <label class="config-card__label">Status</label>
                 <div class="config-value">
-                    <span class="status-indicator @(Store.Workflow.IsActive ? "active" : "inactive")">
-                        @(Store.Workflow.IsActive ? "🟢 Active" : "⚪ Inactive")
+                    <span class="status-indicator @(Store.Workflow.Status == Vyshyvanka.Core.Enums.WorkflowStatus.Active ? "active" : "inactive")">
+                        @Store.Workflow.Status.ToString()
                     </span>
                 </div>
             </div>

--- a/src/Vyshyvanka.Designer/Components/PropertyEditors/WorkflowSelectPropertyEditor.razor.cs
+++ b/src/Vyshyvanka.Designer/Components/PropertyEditors/WorkflowSelectPropertyEditor.razor.cs
@@ -40,7 +40,7 @@ public partial class WorkflowSelectPropertyEditor : ComponentBase
         {
             var workflows = await ApiClient.GetWorkflowsAsync();
             _workflows = workflows
-                .Where(w => w.IsActive)
+                .Where(w => w.Status == Vyshyvanka.Core.Enums.WorkflowStatus.Active)
                 .OrderBy(w => w.Name)
                 .Select(w => new WorkflowOption(w.Id, w.Name))
                 .ToList();

--- a/src/Vyshyvanka.Designer/Components/Workflow/WorkflowBrowser.razor
+++ b/src/Vyshyvanka.Designer/Components/Workflow/WorkflowBrowser.razor
@@ -117,7 +117,7 @@
                                  @onclick="() => SelectWorkflow(workflow.Id)">
                                 <div class="workflow-info">
                                     <div class="workflow-name">
-                                        <span class="status-dot @(workflow.IsActive ? "active" : "inactive")"></span>
+                                        <span class="status-dot @(workflow.Status == Vyshyvanka.Core.Enums.WorkflowStatus.Active ? "active" : "inactive")" title="@workflow.Status.ToString()"></span>
                                         @workflow.Name
                                         @if (workflow.Id == CurrentWorkflowId)
                                         {

--- a/src/Vyshyvanka.Designer/Components/Workflow/WorkflowBrowser.razor.cs
+++ b/src/Vyshyvanka.Designer/Components/Workflow/WorkflowBrowser.razor.cs
@@ -137,7 +137,7 @@ public partial class WorkflowBrowser
 
             var workflows = await workflowsTask;
             _workflows = workflows
-                .Select(w => new WorkflowSummary(w.Id, w.Name, w.Description, w.Version, w.IsActive, w.UpdatedAt, w.FolderId))
+                .Select(w => new WorkflowSummary(w.Id, w.Name, w.Description, w.Version, w.Status, w.UpdatedAt, w.FolderId))
                 .OrderByDescending(w => w.UpdatedAt)
                 .ToList();
 
@@ -564,7 +564,7 @@ public partial class WorkflowBrowser
         string Name,
         string? Description,
         int Version,
-        bool IsActive,
+        Vyshyvanka.Core.Enums.WorkflowStatus Status,
         DateTime UpdatedAt,
         Guid? FolderId);
 

--- a/src/Vyshyvanka.Designer/Layout/DesignerToolbar.razor
+++ b/src/Vyshyvanka.Designer/Layout/DesignerToolbar.razor
@@ -33,13 +33,13 @@
     </span>
 }
 
-<button class="v-toolbar__btn @(Store.Workflow.IsActive ? "v-toolbar__btn--active" : "")"
+<button class="v-toolbar__btn @(Store.Workflow.Status == Vyshyvanka.Core.Enums.WorkflowStatus.Active ? "v-toolbar__btn--active" : "")"
         @onclick="OnToggleActive"
         title="@ActiveTitle"
         aria-label="@ActiveTitle"
-        aria-pressed="@Store.Workflow.IsActive.ToString().ToLowerInvariant()">
-    <span class="v-status-dot @(Store.Workflow.IsActive ? "v-status-dot--active" : "v-status-dot--inactive")"></span>
-    <span>@(Store.Workflow.IsActive ? "Active" : "Inactive")</span>
+        aria-pressed="@((Store.Workflow.Status == Vyshyvanka.Core.Enums.WorkflowStatus.Active).ToString().ToLowerInvariant())">
+    <span class="v-status-dot @(Store.Workflow.Status == Vyshyvanka.Core.Enums.WorkflowStatus.Active ? "v-status-dot--active" : "v-status-dot--inactive")"></span>
+    <span>@(Store.Workflow.Status.ToString())</span>
 </button>
 
 <button class="v-toolbar__btn v-toolbar__btn--primary" @onclick="OnSave" disabled="@(!IsValid)" title="@SaveTitle" aria-label="Save Workflow">

--- a/src/Vyshyvanka.Designer/Layout/DesignerToolbar.razor.cs
+++ b/src/Vyshyvanka.Designer/Layout/DesignerToolbar.razor.cs
@@ -3,7 +3,7 @@ using Vyshyvanka.Designer.Services;
 
 namespace Vyshyvanka.Designer.Layout;
 
-public partial class DesignerToolbar
+public partial class DesignerToolbar : IDisposable
 {
     [Inject] private WorkflowStore Store { get; set; } = null!;
 
@@ -21,12 +21,21 @@ public partial class DesignerToolbar
 
     [Parameter] public EventCallback OnStop { get; set; }
 
+    protected override void OnInitialized()
+    {
+        // Re-render when the loaded workflow changes (e.g. status, or navigating to another workflow).
+        Store.OnStateChanged += OnStoreChanged;
+    }
+
+    private void OnStoreChanged() => StateHasChanged();
+
     private bool IsValid => ValidationService.ValidationResult.IsValid;
 
+    // Designer "Run" issues an Api-mode execution, which is allowed for any status.
+    // Only validity and not-already-running gate it.
     private bool CanExecute =>
         ValidationService.ValidationResult.IsValid
-        && !ExecutionState.IsExecutionActive
-        && Store.Workflow.IsActive;
+        && !ExecutionState.IsExecutionActive;
 
     private string ZoomPercent =>
         FormattableString.Invariant($"{CanvasState.CanvasState.Zoom * 100:0}%");
@@ -35,27 +44,13 @@ public partial class DesignerToolbar
         ? "Save workflow"
         : "Fix validation errors before saving";
 
-    private string RunTitle
-    {
-        get
-        {
-            if (!IsValid)
-            {
-                return "Fix validation errors before running";
-            }
+    private string RunTitle => IsValid
+        ? "Execute workflow"
+        : "Fix validation errors before running";
 
-            if (!Store.Workflow.IsActive)
-            {
-                return "Activate workflow before running";
-            }
-
-            return "Execute workflow";
-        }
-    }
-
-    private string ActiveTitle => Store.Workflow.IsActive
-        ? "Workflow is active (click to deactivate)"
-        : "Workflow is inactive (click to activate)";
+    private string ActiveTitle => Store.Workflow.Status == Core.Enums.WorkflowStatus.Active
+        ? "Workflow is active — automatic triggers armed (click to pause)"
+        : "Workflow is not active — automatic triggers disarmed (click to activate)";
 
     private void Undo() => CanvasState.Undo();
 
@@ -68,4 +63,9 @@ public partial class DesignerToolbar
     private void ResetView() => CanvasState.ResetView();
 
     private void OnToggleActive() => EditService.ToggleWorkflowActive();
+
+    public void Dispose()
+    {
+        Store.OnStateChanged -= OnStoreChanged;
+    }
 }

--- a/src/Vyshyvanka.Designer/Services/WorkflowApiClient.cs
+++ b/src/Vyshyvanka.Designer/Services/WorkflowApiClient.cs
@@ -151,7 +151,7 @@ public class WorkflowApiClient(HttpClient httpClient) : ApiClientBase(httpClient
     {
         Name = workflow.Name,
         Description = workflow.Description,
-        IsActive = workflow.IsActive,
+        Status = workflow.Status,
         Nodes = workflow.Nodes.Select(MapToNodeDto).ToList(),
         Connections = workflow.Connections.Select(MapToConnectionDto).ToList(),
         Settings = MapToSettingsDto(workflow.Settings),
@@ -162,7 +162,7 @@ public class WorkflowApiClient(HttpClient httpClient) : ApiClientBase(httpClient
     {
         Name = workflow.Name,
         Description = workflow.Description,
-        IsActive = workflow.IsActive,
+        Status = workflow.Status,
         Nodes = workflow.Nodes.Select(MapToNodeDto).ToList(),
         Connections = workflow.Connections.Select(MapToConnectionDto).ToList(),
         Settings = MapToSettingsDto(workflow.Settings),
@@ -215,7 +215,7 @@ public class WorkflowApiClient(HttpClient httpClient) : ApiClientBase(httpClient
         Name = response.Name,
         Description = response.Description,
         Version = response.Version,
-        IsActive = response.IsActive,
+        Status = response.Status,
         Nodes = response.Nodes.Select(n => new WorkflowNode
         {
             Id = n.Id,

--- a/src/Vyshyvanka.Designer/Services/WorkflowEditService.cs
+++ b/src/Vyshyvanka.Designer/Services/WorkflowEditService.cs
@@ -189,27 +189,37 @@ public class WorkflowEditService(
         });
     }
 
-    /// <summary>Toggles the workflow active state.</summary>
+    /// <summary>
+    /// Toggles the workflow between Active and non-active. Activating arms automatic triggers;
+    /// deactivating moves to Paused (a Draft that has never been activated stays conceptually the
+    /// same, but the toggle always lands on Active or Paused).
+    /// </summary>
     public void ToggleWorkflowActive()
     {
-        CommitChange("Toggle Workflow Active", w => w with
-        {
-            IsActive = !w.IsActive,
-            UpdatedAt = DateTime.UtcNow
-        }, validate: false);
+        var next = store.Workflow.Status == Core.Enums.WorkflowStatus.Active
+            ? Core.Enums.WorkflowStatus.Paused
+            : Core.Enums.WorkflowStatus.Active;
+        SetWorkflowStatus(next);
     }
 
-    /// <summary>Sets the workflow active state.</summary>
-    public void SetWorkflowActive(bool isActive)
+    /// <summary>Sets the workflow activation status (Draft/Active/Paused).</summary>
+    public void SetWorkflowStatus(Core.Enums.WorkflowStatus status)
     {
-        if (store.Workflow.IsActive == isActive)
+        if (store.Workflow.Status == status)
         {
             return;
         }
 
-        CommitChange(isActive ? "Activate Workflow" : "Deactivate Workflow", w => w with
+        var description = status switch
         {
-            IsActive = isActive,
+            Core.Enums.WorkflowStatus.Active => "Activate Workflow",
+            Core.Enums.WorkflowStatus.Paused => "Pause Workflow",
+            _ => "Set Workflow to Draft"
+        };
+
+        CommitChange(description, w => w with
+        {
+            Status = status,
             UpdatedAt = DateTime.UtcNow
         }, validate: false);
     }

--- a/src/Vyshyvanka.Designer/Services/WorkflowStore.cs
+++ b/src/Vyshyvanka.Designer/Services/WorkflowStore.cs
@@ -168,7 +168,7 @@ public class WorkflowStore
         Id = Guid.NewGuid(),
         Name = "New Workflow",
         Version = 1,
-        IsActive = true,
+        Status = Core.Enums.WorkflowStatus.Draft,
         CreatedAt = DateTime.UtcNow,
         UpdatedAt = DateTime.UtcNow
     };

--- a/src/Vyshyvanka.Engine/Nodes/Actions/ExecuteWorkflowNode.cs
+++ b/src/Vyshyvanka.Engine/Nodes/Actions/ExecuteWorkflowNode.cs
@@ -71,7 +71,7 @@ public class ExecuteWorkflowNode : BaseActionNode
             return FailureOutput($"Workflow '{workflowId}' not found");
         }
 
-        if (!workflow.IsActive)
+        if (workflow.Status != Core.Enums.WorkflowStatus.Active)
         {
             return FailureOutput($"Workflow '{workflow.Name}' is not active");
         }

--- a/src/Vyshyvanka.Engine/Persistence/Entities/WorkflowEntity.cs
+++ b/src/Vyshyvanka.Engine/Persistence/Entities/WorkflowEntity.cs
@@ -19,7 +19,14 @@ public class WorkflowEntity
 
     public int Version { get; set; }
 
-    public bool IsActive { get; set; }
+    /// <summary>Activation state (Draft/Active/Paused). Only Active workflows respond to automatic triggers.</summary>
+    public Vyshyvanka.Core.Enums.WorkflowStatus Status { get; set; }
+
+    /// <summary>
+    /// Scheduler cursor: the last scheduled fire time (UTC) the scheduler dispatched for this workflow.
+    /// Null for workflows that have never been scheduled. Engine-internal; not surfaced over the API.
+    /// </summary>
+    public DateTime? LastScheduledFireAt { get; set; }
 
     /// <summary>JSON-serialized nodes.</summary>
     [Required]

--- a/src/Vyshyvanka.Engine/Persistence/Migrations/20260821114748_WorkflowStatusAndSchedulerCursor.Designer.cs
+++ b/src/Vyshyvanka.Engine/Persistence/Migrations/20260821114748_WorkflowStatusAndSchedulerCursor.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Vyshyvanka.Engine.Persistence;
@@ -11,9 +12,11 @@ using Vyshyvanka.Engine.Persistence;
 namespace Vyshyvanka.Engine.Persistence.Migrations
 {
     [DbContext(typeof(VyshyvankaDbContext))]
-    partial class VyshyvankaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260821114748_WorkflowStatusAndSchedulerCursor")]
+    partial class WorkflowStatusAndSchedulerCursor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Vyshyvanka.Engine/Persistence/Migrations/20260821114748_WorkflowStatusAndSchedulerCursor.cs
+++ b/src/Vyshyvanka.Engine/Persistence/Migrations/20260821114748_WorkflowStatusAndSchedulerCursor.cs
@@ -1,0 +1,78 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Vyshyvanka.Engine.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class WorkflowStatusAndSchedulerCursor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Scheduler cursor for cron/interval dispatch.
+            migrationBuilder.AddColumn<DateTime>(
+                name: "LastScheduledFireAt",
+                table: "Workflows",
+                nullable: true);
+
+            // New activation state column. Add with a default first so existing rows are valid,
+            // then backfill from the old IsActive flag before dropping it (no data loss).
+            migrationBuilder.AddColumn<string>(
+                name: "Status",
+                table: "Workflows",
+                maxLength: 20,
+                nullable: false,
+                defaultValue: "Draft");
+
+            // Backfill: previously-active workflows become Active; everything else stays Draft.
+            migrationBuilder.Sql(
+                "UPDATE \"Workflows\" SET \"Status\" = 'Active' WHERE \"IsActive\" = TRUE;");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Workflows_IsActive",
+                table: "Workflows");
+
+            migrationBuilder.DropColumn(
+                name: "IsActive",
+                table: "Workflows");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Workflows_Status",
+                table: "Workflows",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Re-add the boolean flag and backfill from Status before dropping the new columns.
+            migrationBuilder.AddColumn<bool>(
+                name: "IsActive",
+                table: "Workflows",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.Sql(
+                "UPDATE \"Workflows\" SET \"IsActive\" = TRUE WHERE \"Status\" = 'Active';");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Workflows_Status",
+                table: "Workflows");
+
+            migrationBuilder.DropColumn(
+                name: "LastScheduledFireAt",
+                table: "Workflows");
+
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Workflows");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Workflows_IsActive",
+                table: "Workflows",
+                column: "IsActive");
+        }
+    }
+}

--- a/src/Vyshyvanka.Engine/Persistence/VyshyvankaDbContext.cs
+++ b/src/Vyshyvanka.Engine/Persistence/VyshyvankaDbContext.cs
@@ -55,13 +55,16 @@ public class VyshyvankaDbContext : DbContext
             entity.ToTable("Workflows");
             entity.HasKey(e => e.Id);
             entity.HasIndex(e => e.Name);
-            entity.HasIndex(e => e.IsActive);
+            entity.HasIndex(e => e.Status);
             entity.HasIndex(e => e.CreatedBy);
             entity.HasIndex(e => e.UpdatedAt);
             entity.HasIndex(e => e.FolderId);
 
             entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
             entity.Property(e => e.Description).HasMaxLength(2000);
+            entity.Property(e => e.Status)
+                .HasConversion<string>()
+                .HasMaxLength(20);
             entity.Property(e => e.NodesJson).IsRequired();
             entity.Property(e => e.ConnectionsJson).IsRequired();
 

--- a/src/Vyshyvanka.Engine/Persistence/WorkflowRepository.cs
+++ b/src/Vyshyvanka.Engine/Persistence/WorkflowRepository.cs
@@ -109,7 +109,7 @@ public class WorkflowRepository(VyshyvankaDbContext context) : IWorkflowReposito
     {
         var entities = await context.Workflows
             .AsNoTracking()
-            .Where(w => w.IsActive)
+            .Where(w => w.Status == Core.Enums.WorkflowStatus.Active)
             .OrderByDescending(w => w.UpdatedAt)
             .Skip(skip)
             .Take(take)
@@ -166,7 +166,7 @@ public class WorkflowRepository(VyshyvankaDbContext context) : IWorkflowReposito
 
         var candidates = await context.Workflows
             .AsNoTracking()
-            .Where(w => w.IsActive && EF.Functions.Like(w.NodesJson, pathPattern))
+            .Where(w => w.Status == Core.Enums.WorkflowStatus.Active && EF.Functions.Like(w.NodesJson, pathPattern))
             .ToListAsync(cancellationToken);
 
         return candidates
@@ -191,7 +191,7 @@ public class WorkflowRepository(VyshyvankaDbContext context) : IWorkflowReposito
             Name = workflow.Name,
             Description = workflow.Description,
             Version = workflow.Version,
-            IsActive = workflow.IsActive,
+            Status = workflow.Status,
             NodesJson = JsonSerializer.Serialize(sanitizedNodes, JsonOptions),
             ConnectionsJson = JsonSerializer.Serialize(workflow.Connections, JsonOptions),
             SettingsJson = JsonSerializer.Serialize(workflow.Settings, JsonOptions),
@@ -222,7 +222,7 @@ public class WorkflowRepository(VyshyvankaDbContext context) : IWorkflowReposito
             Name = entity.Name,
             Description = entity.Description,
             Version = entity.Version,
-            IsActive = entity.IsActive,
+            Status = entity.Status,
             Nodes = DeserializeNodes(entity.NodesJson),
             Connections = DeserializeConnections(entity.ConnectionsJson),
             Settings = DeserializeSettings(entity.SettingsJson),
@@ -242,7 +242,7 @@ public class WorkflowRepository(VyshyvankaDbContext context) : IWorkflowReposito
         entity.Name = workflow.Name;
         entity.Description = workflow.Description;
         entity.Version = workflow.Version;
-        entity.IsActive = workflow.IsActive;
+        entity.Status = workflow.Status;
         entity.NodesJson = JsonSerializer.Serialize(sanitizedNodes, JsonOptions);
         entity.ConnectionsJson = JsonSerializer.Serialize(workflow.Connections, JsonOptions);
         entity.SettingsJson = JsonSerializer.Serialize(workflow.Settings, JsonOptions);

--- a/src/Vyshyvanka.Engine/Scheduling/ISchedulePlanner.cs
+++ b/src/Vyshyvanka.Engine/Scheduling/ISchedulePlanner.cs
@@ -1,0 +1,21 @@
+namespace Vyshyvanka.Engine.Scheduling;
+
+/// <summary>
+/// Computes the next fire time for a schedule trigger from a cron expression or a fixed interval.
+/// </summary>
+public interface ISchedulePlanner
+{
+    /// <summary>
+    /// Returns the next occurrence (UTC) strictly after <paramref name="fromUtc"/>, or <c>null</c>
+    /// when no schedule is configured or the cron expression is invalid.
+    /// </summary>
+    /// <param name="cronExpression">Standard 5-field cron expression, or null when using an interval.</param>
+    /// <param name="intervalSeconds">Fixed interval in seconds, or null when using a cron expression. Takes precedence when both are set.</param>
+    /// <param name="fromUtc">The reference time (UTC) to compute the next occurrence after.</param>
+    /// <param name="timeZoneId">IANA/Windows time zone id for cron evaluation. Defaults to UTC.</param>
+    DateTime? GetNextOccurrence(
+        string? cronExpression,
+        int? intervalSeconds,
+        DateTime fromUtc,
+        string timeZoneId = "UTC");
+}

--- a/src/Vyshyvanka.Engine/Scheduling/SchedulePlanner.cs
+++ b/src/Vyshyvanka.Engine/Scheduling/SchedulePlanner.cs
@@ -1,0 +1,65 @@
+using Cronos;
+
+namespace Vyshyvanka.Engine.Scheduling;
+
+/// <summary>
+/// <see cref="ISchedulePlanner"/> implementation backed by <see cref="CronExpression"/> (Cronos)
+/// for cron parsing, with a simple additive rule for fixed intervals.
+/// </summary>
+public sealed class SchedulePlanner : ISchedulePlanner
+{
+    /// <inheritdoc />
+    public DateTime? GetNextOccurrence(
+        string? cronExpression,
+        int? intervalSeconds,
+        DateTime fromUtc,
+        string timeZoneId = "UTC")
+    {
+        // Interval takes precedence when both are configured.
+        if (intervalSeconds is > 0)
+        {
+            return DateTime.SpecifyKind(fromUtc, DateTimeKind.Utc).AddSeconds(intervalSeconds.Value);
+        }
+
+        if (string.IsNullOrWhiteSpace(cronExpression))
+        {
+            return null;
+        }
+
+        CronExpression expression;
+        try
+        {
+            expression = CronExpression.Parse(cronExpression, CronFormat.Standard);
+        }
+        catch (CronFormatException)
+        {
+            return null;
+        }
+
+        var timeZone = ResolveTimeZone(timeZoneId);
+        var fromUtcNormalized = DateTime.SpecifyKind(fromUtc, DateTimeKind.Utc);
+
+        return expression.GetNextOccurrence(fromUtcNormalized, timeZone, inclusive: false);
+    }
+
+    private static TimeZoneInfo ResolveTimeZone(string timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            return TimeZoneInfo.Utc;
+        }
+
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            return TimeZoneInfo.Utc;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            return TimeZoneInfo.Utc;
+        }
+    }
+}

--- a/src/Vyshyvanka.Engine/Scheduling/WorkflowSchedulerService.cs
+++ b/src/Vyshyvanka.Engine/Scheduling/WorkflowSchedulerService.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Vyshyvanka.Core.Enums;
+using Vyshyvanka.Core.Interfaces;
+using Vyshyvanka.Core.Models;
+using Vyshyvanka.Engine.Credentials;
+using Vyshyvanka.Engine.Persistence;
+using ExecutionContext = Vyshyvanka.Engine.Execution.ExecutionContext;
+
+namespace Vyshyvanka.Engine.Scheduling;
+
+/// <summary>
+/// Hosted background service that fires schedule-triggered workflows.
+/// On each tick it loads active workflows containing a schedule-trigger node, computes each one's
+/// next fire time from its cron expression or interval, and dispatches an execution (mode
+/// <see cref="ExecutionMode.Scheduled"/>) for any that are due. Missed fires while the host was
+/// down are skipped (next occurrence is computed forward from now).
+/// </summary>
+/// <remarks>
+/// Single-instance design: assumes one scheduler runs per deployment. See the SDD for the
+/// multi-instance hardening path (advisory lock + cursor optimistic guard).
+/// </remarks>
+public sealed class WorkflowSchedulerService(
+    IServiceScopeFactory scopeFactory,
+    ISchedulePlanner planner,
+    ILogger<WorkflowSchedulerService> logger) : BackgroundService
+{
+    private const string ScheduleTriggerType = "schedule-trigger";
+
+    /// <summary>How often the scheduler wakes to evaluate due workflows.</summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
+
+    /// <inheritdoc />
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Workflow scheduler started (poll interval {Seconds}s)", PollInterval.TotalSeconds);
+
+        using var timer = new PeriodicTimer(PollInterval);
+
+        // Run one pass immediately, then on each tick.
+        do
+        {
+            try
+            {
+                await TickAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                // Never let a single bad tick tear down the service.
+                logger.LogError(ex, "Workflow scheduler tick failed");
+            }
+        }
+        while (await timer.WaitForNextTickAsync(stoppingToken));
+
+        logger.LogInformation("Workflow scheduler stopped");
+    }
+
+    private async Task TickAsync(CancellationToken cancellationToken)
+    {
+        using var scope = scopeFactory.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<VyshyvankaDbContext>();
+        var repository = scope.ServiceProvider.GetRequiredService<IWorkflowRepository>();
+        var engine = scope.ServiceProvider.GetRequiredService<IWorkflowEngine>();
+        var executionRepository = scope.ServiceProvider.GetRequiredService<IExecutionRepository>();
+        var credentialService = scope.ServiceProvider.GetService<ICredentialService>();
+
+        var now = DateTime.UtcNow;
+
+        // Candidate entities: Active, and their NodesJson mentions the schedule-trigger type.
+        // The type filter narrows the set in SQL; exact node inspection happens on the model below.
+        var candidates = await db.Workflows
+            .Where(w => w.Status == WorkflowStatus.Active
+                        && EF.Functions.Like(w.NodesJson, $"%\"{ScheduleTriggerType}\"%"))
+            .ToListAsync(cancellationToken);
+
+        foreach (var entity in candidates)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var workflow = await repository.GetByIdAsync(entity.Id, cancellationToken);
+            if (workflow is null)
+            {
+                continue;
+            }
+
+            var scheduleNode = workflow.Nodes.FirstOrDefault(n =>
+                n.Type.Equals(ScheduleTriggerType, StringComparison.OrdinalIgnoreCase));
+            if (scheduleNode is null)
+            {
+                continue;
+            }
+
+            var (cron, interval, timezone) = ReadScheduleConfig(scheduleNode);
+            if (cron is null && interval is null)
+            {
+                continue;
+            }
+
+            // Compute the next fire relative to the persisted cursor (or activation baseline / now).
+            var baseline = entity.LastScheduledFireAt ?? entity.UpdatedAt;
+            if (baseline > now)
+            {
+                baseline = now;
+            }
+
+            var nextFire = planner.GetNextOccurrence(cron, interval, baseline, timezone ?? "UTC");
+            if (nextFire is null || nextFire.Value > now)
+            {
+                continue; // not due yet
+            }
+
+            // Overlap guard: skip if a prior scheduled run for this workflow is still in flight.
+            var hasRunning = await db.Executions.AnyAsync(
+                e => e.WorkflowId == workflow.Id
+                     && (e.Status == ExecutionStatus.Running || e.Status == ExecutionStatus.Pending),
+                cancellationToken);
+            if (hasRunning)
+            {
+                logger.LogDebug("Skipping scheduled run for {WorkflowId}: a prior run is still active", workflow.Id);
+                continue;
+            }
+
+            await DispatchAsync(workflow, scope.ServiceProvider, engine, credentialService, nextFire.Value, cancellationToken);
+
+            // Advance the cursor so the next tick computes the following occurrence.
+            entity.LastScheduledFireAt = nextFire.Value;
+            await db.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private async Task DispatchAsync(
+        Workflow workflow,
+        IServiceProvider services,
+        IWorkflowEngine engine,
+        ICredentialService? credentialService,
+        DateTime scheduledTime,
+        CancellationToken cancellationToken)
+    {
+        var executionId = Guid.NewGuid();
+
+        ICredentialProvider credentialProvider = credentialService is not null
+            ? new OwnerCredentialProvider(credentialService, workflow.CreatedBy)
+            : NullCredentialProvider.Instance;
+
+        var context = new ExecutionContext(
+            executionId,
+            workflow.Id,
+            credentialProvider,
+            cancellationToken,
+            services,
+            workflow.CreatedBy,
+            logger);
+
+        // Populate the trigger context so ScheduleTriggerNode.ShouldTriggerAsync fires.
+        context.Variables["triggerType"] = "schedule";
+        context.Variables["scheduledTime"] = scheduledTime;
+
+        logger.LogInformation(
+            "Dispatching scheduled execution {ExecutionId} for workflow {WorkflowId} (scheduled {ScheduledTime:o})",
+            executionId, workflow.Id, scheduledTime);
+
+        try
+        {
+            await engine.ExecuteAsync(workflow, context, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Scheduled execution {ExecutionId} for workflow {WorkflowId} failed",
+                executionId, workflow.Id);
+        }
+    }
+
+    private static (string? Cron, int? Interval, string? Timezone) ReadScheduleConfig(WorkflowNode node)
+    {
+        if (node.Configuration.ValueKind != JsonValueKind.Object)
+        {
+            return (null, null, null);
+        }
+
+        string? cron = null;
+        int? interval = null;
+        string? timezone = null;
+
+        if (node.Configuration.TryGetProperty("cronExpression", out var cronProp)
+            && cronProp.ValueKind == JsonValueKind.String)
+        {
+            cron = cronProp.GetString();
+        }
+
+        if (node.Configuration.TryGetProperty("interval", out var intervalProp)
+            && intervalProp.ValueKind == JsonValueKind.Number
+            && intervalProp.TryGetInt32(out var intervalValue))
+        {
+            interval = intervalValue;
+        }
+
+        if (node.Configuration.TryGetProperty("timezone", out var tzProp)
+            && tzProp.ValueKind == JsonValueKind.String)
+        {
+            timezone = tzProp.GetString();
+        }
+
+        return (string.IsNullOrWhiteSpace(cron) ? null : cron, interval, timezone);
+    }
+}

--- a/src/Vyshyvanka.Engine/Vyshyvanka.Engine.csproj
+++ b/src/Vyshyvanka.Engine/Vyshyvanka.Engine.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Cronos" />
     <PackageReference Include="Jint" />
     <PackageReference Include="Jsonata.Net.Native" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />

--- a/tests/Vyshyvanka.Tests/Integration/ExecutionApiTests.cs
+++ b/tests/Vyshyvanka.Tests/Integration/ExecutionApiTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using Vyshyvanka.Api.Models;
 using Vyshyvanka.Contracts.Executions;
 using Vyshyvanka.Contracts.Workflows;
+using Vyshyvanka.Core.Enums;
 using Vyshyvanka.Tests.Integration.Fixtures;
 
 namespace Vyshyvanka.Tests.Integration;
@@ -21,7 +22,7 @@ public class ExecutionApiTests : IClassFixture<VyshyvankaWebApplicationFactory>
         var request = new CreateWorkflowRequest
         {
             Name = "Execution Test Workflow",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -55,13 +56,14 @@ public class ExecutionApiTests : IClassFixture<VyshyvankaWebApplicationFactory>
     }
 
     [Fact]
-    public async Task WhenTriggeringExecutionForInactiveWorkflowThenReturns400()
+    public async Task WhenManuallyTriggeringDraftWorkflowThenAllowed()
     {
-        // Create inactive workflow
+        // Draft workflows are NOT armed for automatic triggers, but manual/API execution
+        // must still be allowed so a workflow can be developed and tested from the Designer.
         var createRequest = new CreateWorkflowRequest
         {
-            Name = "Inactive Workflow",
-            IsActive = false,
+            Name = "Draft Workflow",
+            Status = WorkflowStatus.Draft,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -78,14 +80,49 @@ public class ExecutionApiTests : IClassFixture<VyshyvankaWebApplicationFactory>
 
         var request = new TriggerExecutionRequest
         {
-            WorkflowId = workflow!.Id
+            WorkflowId = workflow!.Id,
+            Mode = ExecutionMode.Manual
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/execution", request);
+
+        // Manual execution of a Draft workflow is permitted (not gated on activation).
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+    }
+
+    [Fact]
+    public async Task WhenAutomaticTriggerModeForNonActiveWorkflowThenReturns400()
+    {
+        // Automatic-trigger modes (Trigger/Scheduled) are only served for Active workflows.
+        var createRequest = new CreateWorkflowRequest
+        {
+            Name = "Draft Workflow (auto-trigger attempt)",
+            Status = WorkflowStatus.Draft,
+            Nodes =
+            [
+                new WorkflowNodeDto
+                {
+                    Id = "trigger-1",
+                    Type = "manual-trigger",
+                    Name = "Start",
+                    Position = new PositionDto(0, 0)
+                }
+            ]
+        };
+        var createResponse = await _client.PostAsJsonAsync("/api/workflow", createRequest);
+        var workflow = await createResponse.Content.ReadFromJsonAsync<WorkflowResponse>();
+
+        var request = new TriggerExecutionRequest
+        {
+            WorkflowId = workflow!.Id,
+            Mode = ExecutionMode.Scheduled
         };
 
         var response = await _client.PostAsJsonAsync("/api/execution", request);
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var error = await response.Content.ReadFromJsonAsync<ApiError>();
-        error!.Code.Should().Be("WORKFLOW_INACTIVE");
+        error!.Code.Should().Be("WORKFLOW_NOT_ACTIVE");
     }
 
     // --- Get execution by ID ---

--- a/tests/Vyshyvanka.Tests/Integration/SyncWebhookTests.cs
+++ b/tests/Vyshyvanka.Tests/Integration/SyncWebhookTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Vyshyvanka.Api.Models;
+using Vyshyvanka.Core.Enums;
 using Vyshyvanka.Tests.Integration.Fixtures;
 
 namespace Vyshyvanka.Tests.Integration;
@@ -41,7 +42,7 @@ public class SyncWebhookTests : IClassFixture<VyshyvankaWebApplicationFactory>
         {
             Name = "Sync Webhook Test",
             Description = "Workflow with sync response mode",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -107,7 +108,7 @@ public class SyncWebhookTests : IClassFixture<VyshyvankaWebApplicationFactory>
         var request = new CreateWorkflowRequest
         {
             Name = "Async Webhook Test",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -151,7 +152,7 @@ public class SyncWebhookTests : IClassFixture<VyshyvankaWebApplicationFactory>
         var request = new CreateWorkflowRequest
         {
             Name = "Auth Header Webhook",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -213,7 +214,7 @@ public class SyncWebhookTests : IClassFixture<VyshyvankaWebApplicationFactory>
         var request = new CreateWorkflowRequest
         {
             Name = "No Auth Header Webhook",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -276,7 +277,7 @@ public class SyncWebhookTests : IClassFixture<VyshyvankaWebApplicationFactory>
         var request = new CreateWorkflowRequest
         {
             Name = "RawBody Webhook",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -331,7 +332,7 @@ public class SyncWebhookTests : IClassFixture<VyshyvankaWebApplicationFactory>
         var request = new CreateWorkflowRequest
         {
             Name = "Inactive Workflow",
-            IsActive = false,
+            Status = WorkflowStatus.Draft,
             Nodes =
             [
                 new WorkflowNodeDto
@@ -353,7 +354,7 @@ public class SyncWebhookTests : IClassFixture<VyshyvankaWebApplicationFactory>
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var error = await response.Content.ReadFromJsonAsync<JsonElement>();
-        error.GetProperty("code").GetString().Should().Be("WORKFLOW_INACTIVE");
+        error.GetProperty("code").GetString().Should().Be("WORKFLOW_NOT_ACTIVE");
     }
 
     [Fact]

--- a/tests/Vyshyvanka.Tests/Integration/WorkflowApiTests.cs
+++ b/tests/Vyshyvanka.Tests/Integration/WorkflowApiTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using Vyshyvanka.Api.Models;
 using Vyshyvanka.Contracts;
 using Vyshyvanka.Contracts.Workflows;
+using Vyshyvanka.Core.Enums;
 using Vyshyvanka.Tests.Integration.Fixtures;
 
 namespace Vyshyvanka.Tests.Integration;
@@ -20,7 +21,7 @@ public class WorkflowApiTests : IClassFixture<VyshyvankaWebApplicationFactory>
     {
         Name = name,
         Description = "A test workflow",
-        IsActive = true,
+        Status = WorkflowStatus.Active,
         Nodes =
         [
             new WorkflowNodeDto
@@ -147,7 +148,7 @@ public class WorkflowApiTests : IClassFixture<VyshyvankaWebApplicationFactory>
         var updateRequest = new UpdateWorkflowRequest
         {
             Name = "Updated Workflow",
-            IsActive = false,
+            Status = WorkflowStatus.Draft,
             Version = created!.Version,
             Nodes =
             [
@@ -230,13 +231,13 @@ public class WorkflowApiTests : IClassFixture<VyshyvankaWebApplicationFactory>
     [Fact]
     public async Task WhenGettingActiveWorkflowsThenReturnsOnlyActive()
     {
-        await _client.PostAsJsonAsync("/api/workflow", CreateValidRequest("Active") with { IsActive = true });
+        await _client.PostAsJsonAsync("/api/workflow", CreateValidRequest("Active") with { Status = WorkflowStatus.Active });
 
         var response = await _client.GetAsync("/api/workflow/active");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         var paged = await response.Content.ReadFromJsonAsync<PagedResponse<WorkflowResponse>>();
         paged.Should().NotBeNull();
-        paged!.Items.Should().OnlyContain(w => w.IsActive);
+        paged!.Items.Should().OnlyContain(w => w.Status == WorkflowStatus.Active);
     }
 }

--- a/tests/Vyshyvanka.Tests/Unit/Nodes/ExecuteWorkflowNodeTests.cs
+++ b/tests/Vyshyvanka.Tests/Unit/Nodes/ExecuteWorkflowNodeTests.cs
@@ -132,7 +132,7 @@ public class ExecuteWorkflowNodeTests
         {
             Id = targetWorkflowId,
             Name = "Inactive Workflow",
-            IsActive = false
+            Status = WorkflowStatus.Draft
         };
 
         var workflowRepo = Substitute.For<IWorkflowRepository>();
@@ -170,7 +170,7 @@ public class ExecuteWorkflowNodeTests
         {
             Id = targetWorkflowId,
             Name = "Other User Workflow",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             CreatedBy = ownerId
         };
 
@@ -208,7 +208,7 @@ public class ExecuteWorkflowNodeTests
         {
             Id = targetWorkflowId,
             Name = "Child Workflow",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             CreatedBy = currentUserId
         };
 
@@ -263,7 +263,7 @@ public class ExecuteWorkflowNodeTests
         {
             Id = targetWorkflowId,
             Name = "Failing Child",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             CreatedBy = currentUserId
         };
 
@@ -312,7 +312,7 @@ public class ExecuteWorkflowNodeTests
         {
             Id = targetWorkflowId,
             Name = "Any User Workflow",
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             CreatedBy = otherUserId
         };
 

--- a/tests/Vyshyvanka.Tests/Unit/Scheduling/SchedulePlannerTests.cs
+++ b/tests/Vyshyvanka.Tests/Unit/Scheduling/SchedulePlannerTests.cs
@@ -1,0 +1,96 @@
+using AwesomeAssertions;
+using CsCheck;
+using Vyshyvanka.Engine.Scheduling;
+
+namespace Vyshyvanka.Tests.Unit.Scheduling;
+
+public class SchedulePlannerTests
+{
+    private readonly SchedulePlanner _sut = new();
+
+    [Fact]
+    public void WhenCronIsWeekdaysAt9ThenNextOccurrenceMatches()
+    {
+        // Monday 2026-01-05 08:00 UTC -> next weekday-9am is same day 09:00.
+        var from = new DateTime(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+        var next = _sut.GetNextOccurrence("0 9 * * 1-5", null, from);
+
+        next.Should().Be(new DateTime(2026, 1, 5, 9, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void WhenCronIsEvery15MinutesThenNextOccurrenceIsNextQuarter()
+    {
+        var from = new DateTime(2026, 1, 5, 8, 7, 0, DateTimeKind.Utc);
+
+        var next = _sut.GetNextOccurrence("*/15 * * * *", null, from);
+
+        next.Should().Be(new DateTime(2026, 1, 5, 8, 15, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void WhenIntervalIsSetThenNextOccurrenceIsFromPlusInterval()
+    {
+        var from = new DateTime(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+        var next = _sut.GetNextOccurrence(null, 300, from);
+
+        next.Should().Be(from.AddSeconds(300));
+    }
+
+    [Fact]
+    public void WhenBothCronAndIntervalSetThenIntervalWins()
+    {
+        var from = new DateTime(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+        var next = _sut.GetNextOccurrence("0 9 * * *", 60, from);
+
+        next.Should().Be(from.AddSeconds(60));
+    }
+
+    [Fact]
+    public void WhenCronIsInvalidThenReturnsNull()
+    {
+        var from = new DateTime(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+        var next = _sut.GetNextOccurrence("not a cron", null, from);
+
+        next.Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenNeitherCronNorIntervalThenReturnsNull()
+    {
+        var from = new DateTime(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+        var next = _sut.GetNextOccurrence(null, null, from);
+
+        next.Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenUnknownTimezoneThenFallsBackToUtc()
+    {
+        var from = new DateTime(2026, 1, 5, 8, 0, 0, DateTimeKind.Utc);
+
+        var next = _sut.GetNextOccurrence("0 9 * * *", null, from, "Not/AZone");
+
+        next.Should().Be(new DateTime(2026, 1, 5, 9, 0, 0, DateTimeKind.Utc));
+    }
+
+    [Fact]
+    public void WhenCronValidThenNextOccurrenceIsAlwaysStrictlyAfterFrom()
+    {
+        // Property: for a fixed valid cron, the next occurrence is always in the future.
+        Gen.DateTime[new DateTime(2000, 1, 1), new DateTime(2100, 1, 1)]
+            .Sample(from =>
+            {
+                var fromUtc = DateTime.SpecifyKind(from, DateTimeKind.Utc);
+                var next = _sut.GetNextOccurrence("0 * * * *", null, fromUtc);
+
+                next.Should().NotBeNull();
+                next!.Value.Should().BeAfter(fromUtc);
+            });
+    }
+}

--- a/tests/Vyshyvanka.Tests/Unit/WorkflowApiClientTests.cs
+++ b/tests/Vyshyvanka.Tests/Unit/WorkflowApiClientTests.cs
@@ -45,7 +45,7 @@ public class WorkflowApiClientTests
         var id = Guid.NewGuid();
         var json = $$"""
         {
-            "id":"{{id}}","name":"Test","version":1,"isActive":true,
+            "id":"{{id}}","name":"Test","version":1,"status":1,
             "nodes":[],"connections":[],"tags":[],
             "createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"
         }
@@ -65,7 +65,7 @@ public class WorkflowApiClientTests
     {
         var json = """
         {
-            "id":"00000000-0000-0000-0000-000000000001","name":"New","version":1,"isActive":true,
+            "id":"00000000-0000-0000-0000-000000000001","name":"New","version":1,"status":1,
             "nodes":[],"connections":[],"tags":[],
             "createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"
         }
@@ -73,7 +73,7 @@ public class WorkflowApiClientTests
         var handler = new MockHttpHandler(MockHttpHandler.JsonResponse(json));
         var sut = CreateClient(handler);
 
-        var workflow = new Vyshyvanka.Core.Models.Workflow { Name = "New", IsActive = true };
+        var workflow = new Vyshyvanka.Core.Models.Workflow { Name = "New", Status = Vyshyvanka.Core.Enums.WorkflowStatus.Active };
         var result = await sut.CreateWorkflowAsync(workflow);
 
         handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
@@ -87,7 +87,7 @@ public class WorkflowApiClientTests
         var id = Guid.NewGuid();
         var json = $$"""
         {
-            "id":"{{id}}","name":"Updated","version":2,"isActive":true,
+            "id":"{{id}}","name":"Updated","version":2,"status":1,
             "nodes":[],"connections":[],"tags":[],
             "createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"
         }

--- a/tests/Vyshyvanka.Tests/Unit/WorkflowEditServiceTests.cs
+++ b/tests/Vyshyvanka.Tests/Unit/WorkflowEditServiceTests.cs
@@ -189,19 +189,19 @@ public class WorkflowEditServiceTests
     [Fact]
     public void WhenToggleWorkflowActiveThenStateFlips()
     {
-        var original = _store.Workflow.IsActive;
+        var wasActive = _store.Workflow.Status == WorkflowStatus.Active;
 
         _sut.ToggleWorkflowActive();
 
-        _store.Workflow.IsActive.Should().Be(!original);
+        (_store.Workflow.Status == WorkflowStatus.Active).Should().Be(!wasActive);
     }
 
     [Fact]
     public void WhenSetWorkflowActiveToSameValueThenNoOp()
     {
-        var original = _store.Workflow.IsActive;
+        var original = _store.Workflow.Status;
 
-        _sut.SetWorkflowActive(original);
+        _sut.SetWorkflowStatus(original);
 
         _canvasState.CanUndo.Should().BeFalse(); // No undo state saved
     }
@@ -246,7 +246,7 @@ public class WorkflowEditServiceTests
             Id = Guid.NewGuid(),
             Name = "Loaded Workflow",
             Version = 3,
-            IsActive = true,
+            Status = WorkflowStatus.Active,
             Nodes = [new WorkflowNode { Id = "x1", Type = "if", Name = "Loaded Node" }]
         };
 

--- a/tests/Vyshyvanka.Tests/Unit/WorkflowValidatorTests.cs
+++ b/tests/Vyshyvanka.Tests/Unit/WorkflowValidatorTests.cs
@@ -1,3 +1,4 @@
+using Vyshyvanka.Core.Enums;
 using Vyshyvanka.Core.Models;
 using Vyshyvanka.Engine.Validation;
 
@@ -12,7 +13,7 @@ public class WorkflowValidatorTests
         Id = Guid.NewGuid(),
         Name = "Test Workflow",
         Version = 1,
-        IsActive = true,
+        Status = WorkflowStatus.Active,
         Nodes =
         [
             new WorkflowNode { Id = "trigger-1", Type = "manual-trigger", Name = "Start" },


### PR DESCRIPTION
The core problem is solved: activation (WorkflowStatus) now governs only whether automatic triggers are armed. Manual/Designer/API execution works for any status, so you can develop an active workflow without a live cron firing mid-session — and now there's a real scheduler for it to fire from when Active.